### PR TITLE
Remove references to nonexistent currency-doc-2022.xml and stpr-doc-2022.xml files.

### DIFF
--- a/resources/TaxonomyAddonManager.xml
+++ b/resources/TaxonomyAddonManager.xml
@@ -109,13 +109,6 @@
       <ReferenceFiles/>
     </TaxonomyAddon>
     <TaxonomyAddon>
-      <Taxonomy>currency-2022.xsd</Taxonomy>
-      <DefinitionFiles>
-        <string>currency-doc-2022.xml</string>
-      </DefinitionFiles>
-      <ReferenceFiles/>
-    </TaxonomyAddon>
-    <TaxonomyAddon>
       <Taxonomy>dei-2009-01-31.xsd</Taxonomy>
       <DefinitionFiles>
         <string>dei-doc-2009-01-31.xml</string>
@@ -493,13 +486,6 @@
       <Taxonomy>stpr-2018-01-31.xsd</Taxonomy>
       <DefinitionFiles>
         <string>stpr-doc-2018-01-31.xml</string>
-      </DefinitionFiles>
-      <ReferenceFiles/>
-    </TaxonomyAddon>
-    <TaxonomyAddon>
-      <Taxonomy>stpr-2022.xsd</Taxonomy>
-      <DefinitionFiles>
-        <string>stpr-doc-2022.xml</string>
       </DefinitionFiles>
       <ReferenceFiles/>
     </TaxonomyAddon>


### PR DESCRIPTION
Test by validating a document from a 2022 taxonomy using currency and stpr concepts, e.g. USGAAP 2022, and verifying that you don't get `No such file or directory` validation errors for those files.