### PR TITLE
Edgar 22.2.2 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ domestic copyright protection. 17 U.S.C. 105.
 End user support is by e-mail direct to SEC at: [StructuredData@sec.gov]
 (mailto:StructuredData@sec.gov).
 
-This is EDGAR release 22.2, in production June 20, 2022.
+This is EDGAR release 22.2.2, in production August, 2022.
 
 Developer issue management is by the Jira Edgar Renderer project: https://arelle.atlassian.net/projects/ER
 

--- a/__init__.py
+++ b/__init__.py
@@ -143,7 +143,7 @@ Language of labels:
     GUI may use tools->language labels setting to override system language for labels
         
 """
-VERSION = '3.22.2'
+VERSION = '3.22.2.2'
 
 from collections import defaultdict
 from arelle import PythonUtil  # define 2.x or 3.x string types
@@ -254,6 +254,8 @@ class EdgarRenderer(Cntlr.Cntlr):
         self.createdFolders = []
         self.success = True
         self.labelLangs = ['en-US','en-GB'] # list by WcH 7/14/2017, priority of label langs, en-XX always falls back to en anyway
+        if not hasattr(cntlr, "edgarRedlineDocs"): # in GUI mode initialized before this class init
+            cntlr.edgarRedlineDocs = {}
 
     # wrap controler properties as needed
 
@@ -918,7 +920,7 @@ class EdgarRenderer(Cntlr.Cntlr):
                             target = join(self.reportsFolder, filename)
                             if exists(target): remove(target)
                             filing.writeFile(target, file.read())
-
+                    
                 self.logDebug("Instance post-processing complete {:.3f} secs.".format(time.time() - _startedAt))
 
                 # temporary work-around to create SDR summaryDict
@@ -939,6 +941,7 @@ class EdgarRenderer(Cntlr.Cntlr):
 
                 summary = Summary.Summary(self)
                 rootETree = summary.buildSummaryETree()
+                dissemReportsFolder = None
                 if self.reportZip or self.reportsFolder is not None:
                     IoManager.writeXmlDoc(filing, rootETree, self.reportZip, self.reportsFolder, 'FilingSummary.xml')
                     # if there's a dissem directory and no logs, remove summary logs
@@ -997,16 +1000,22 @@ class EdgarRenderer(Cntlr.Cntlr):
                                 _xbrldir = os.path.dirname(filepath)
                                 for reportedFile in sorted(report.reportedFiles):
                                     if reportedFile not in xbrlZip.namelist():
-                                        if filesource.isArchive and reportedFile in filesource.dir:
-                                            _filepath = os.path.join(filesource.baseurl, reportedFile)
+                                        if reportedFile in cntlr.edgarRedlineDocs:
+                                            doc = cntlr.edgarRedlineDocs[reportedFile]
+                                            # redline removed file is not readable in encoded version, create from dom in memory
+                                            xbrlZip.writestr(reportedFile, 
+                                                             etree.tostring(doc.xmlRootElement, encoding=doc.documentEncoding, xml_declaration=True).decode('utf-8'))
                                         else:
-                                            _filepath = os.path.join(_xbrldir, reportedFile)
-                                        if sourceZipStream is not None:
-                                            file = FileSource.openFileSource(_filepath, cntlr, sourceZipStream).file(_filepath, binary=True)[0]
-                                        else:
-                                            file = filesource.file(_filepath, binary=True)[0]  # returned in a tuple
-                                        xbrlZip.writestr(reportedFile, file.read())
-                                        file.close()
+                                            if filesource.isArchive and reportedFile in filesource.dir:
+                                                _filepath = os.path.join(filesource.baseurl, reportedFile)
+                                            else:
+                                                _filepath = os.path.join(_xbrldir, reportedFile)
+                                            if sourceZipStream is not None:
+                                                file = FileSource.openFileSource(_filepath, cntlr, sourceZipStream).file(_filepath, binary=True)[0]
+                                            else:
+                                                file = filesource.file(_filepath, binary=True)[0]  # returned in a tuple
+                                            xbrlZip.writestr(reportedFile, file.read())
+                                            file.close()
                             filesource.close()
                         xbrlZip.close()
                         zipStream.seek(0)
@@ -1016,6 +1025,14 @@ class EdgarRenderer(Cntlr.Cntlr):
                             self.writeFile(os.path.join(self.reportsFolder, _fileName), zipStream.read())
                         zipStream.close()
                         self.logDebug("Write {} complete".format(_fileName))
+
+                # save documents with removed redlines (only when saving dissemReportsFolder)
+                if dissemReportsFolder:
+                    for reportedFile, modelDocument in cntlr.edgarRedlineDocs.items():
+                        target = join(dissemReportsFolder, reportedFile) + ".redlineRemoved"
+                        os.makedirs(self.reportsFolder, exist_ok=True)
+                        filing.writeFile(target,
+                            etree.tostring(modelDocument.xmlRootElement, encoding=modelDocument.documentEncoding, xml_declaration=True))
 
                 if "EdgarRenderer/__init__.py#filingEnd" in filing.arelleUnitTests:
                     raise arelle.PythonUtil.pyNamedObject(filing.arelleUnitTests["EdgarRenderer/__init__.py#filingEnd"], "EdgarRenderer/__init__.py#filingEnd")
@@ -1042,6 +1059,8 @@ class EdgarRenderer(Cntlr.Cntlr):
                 self.logDebug(_("Exception in filing end processing, traceback: {}").format(traceback.format_exception(*sys.exc_info())))
                 self.success = False # force postprocessingFailure
 
+            cntlr.edgarRedlineDocs.clear()
+            
         if not self.success and self.isDaemon: # not successful
             self.postprocessFailure(filing.options)
 
@@ -1284,6 +1303,8 @@ def edgarRendererGuiRun(cntlr, modelXbrl, attach, *args, **kwargs):
                 _ixRedline = "?redline=true"
             else:
                 _ixRedline = ""
+        if not hasattr(cntlr, "edgarRedlineDocs"):
+            cntlr.edgarRedlineDocs = {}
         isNonEFMorGFMinline = (not getattr(cntlr.modelManager.disclosureSystem, "EFMplugin", False) and
                                modelXbrl.modelDocument.type in (ModelDocument.Type.INLINEXBRL, ModelDocument.Type.INLINEXBRLDOCUMENTSET))
         # may use GUI mode to process a single instance or test suite
@@ -1470,6 +1491,41 @@ def testcaseVariationExpectedSeverity(modelTestcaseVariation, *args, **kwargs):
 def savesTargetInstance(*args, **kwargs): # EdgarRenderer implements its own target instance saver
     return True
 
+redliningPattern = re.compile(r"(.*;)?\s*-sec-ix-redline\s*:\s*true(?:\s*;)?\s*([\w.-].*)?$")
+def edgarRendererRemoveRedlining(modelDocument, *args, **kwargs):
+    cntlr = modelDocument.modelXbrl.modelManager.cntlr
+    if modelDocument.type == ModelDocument.Type.INLINEXBRL and (not cntlr.hasGui or not cntlr.redlineMode.get()):
+        rlRemoved = False
+        # strip redlining from modelDocument
+        for e in modelDocument.xmlRootElement.getroottree().iterfind("//{http://www.w3.org/1999/xhtml}*[@style]"):
+            rlMatch = redliningPattern.match(e.get("style",""))
+            if rlMatch:
+                rlRemoved = True
+                cleanedStyle = (rlMatch.group(1) or "") + (rlMatch.group(2) or "")
+                if cleanedStyle:
+                    e.set("style", cleanedStyle)
+                else:
+                    e.attrib.pop("style")
+                    if not e.attrib: # no other elements, remove this one
+                        e0 = e.getprevious()
+                        prop = "tail"
+                        if e0 is None:
+                            e0 = e.getparent()
+                            prop = "text"
+                        if e.text:
+                            setattr(e0, prop, (getattr(e0, prop) or "") + e.text)
+                        for eChild in e.getchildren():
+                            e.addprevious(eChild)
+                            e0 = eChild
+                            prop = "tail"
+                        if e.tail:
+                            setattr(e0, prop, (getattr(e0, prop) or "") + e.tail)
+                        e.getparent().remove(e)
+        if rlRemoved:
+            if not hasattr(cntlr, "edgarRedlineDocs"):
+                cntlr.edgarRedlineDocs = {}
+            cntlr.edgarRedlineDocs[modelDocument.basename] = modelDocument
+
 __pluginInfo__ = {
     'name': 'Edgar Renderer',
     'version': VERSION,
@@ -1490,6 +1546,8 @@ __pluginInfo__ = {
     'EdgarRenderer.Filing.End': edgarRendererFilingEnd,
     # GUI operation start log buffering
     'ModelDocument.IsPullLoadable': edgarRendererGuiStartLogging,
+    # remove redline markups when appropriate
+    'ModelDocument.Discover': edgarRendererRemoveRedlining,
     # GUI operation startup (renders all reports of an input instance or test suite)
     'CntlrWinMain.Xbrl.Loaded': edgarRendererGuiRun,
     # GUI operation, add View -> EdgarRenderer submenu for GUI options

--- a/ixviewer-src/ix-dev.html
+++ b/ixviewer-src/ix-dev.html
@@ -735,7 +735,7 @@
 							</button>
 						</h5>
 					</div>
-					<div id="ccollapseFeeExhibit" class="reboot collapse"
+					<div id="collapseFeeExhibit" class="reboot collapse"
 						data-parent="#tagged-sections">
 						<!-- Below is populated dynamically VIA JS -->
 						<div class="reboot list-group list-group-flush"></div>

--- a/ixviewer-src/ix-dev.html
+++ b/ixviewer-src/ix-dev.html
@@ -695,6 +695,52 @@
 						<div class="reboot list-group list-group-flush"></div>
 					</div>
 				</div>
+
+				<div class="reboot card" id="tagged-sections-4"
+					data-test="tagged-sections-4">
+					<div class="reboot card-header px-0 py-0">
+						<h5 class="reboot mb-0">
+							<button
+								class="reboot btn btn-link d-flex justify-content-between align-items-center w-100"
+								type="button" data-target="#collapseProspectus">
+								<span class="reboot font-size-1">Prospectus</span>
+								<span id="collapseProspectusBadge"
+									class="reboot badge badge-secondary">
+									<i class="reboot fas fa-spinner fa-spin"></i>
+
+								</span>
+							</button>
+						</h5>
+					</div>
+					<div id="collapseProspectus" class="reboot collapse"
+						data-parent="#tagged-sections">
+						<!-- Below is populated dynamically VIA JS -->
+						<div class="reboot list-group list-group-flush"></div>
+					</div>
+				</div>
+
+				<div class="reboot card" id="tagged-sections-5"
+					data-test="tagged-sections-5">
+					<div class="reboot card-header px-0 py-0">
+						<h5 class="reboot mb-0">
+							<button
+								class="reboot btn btn-link d-flex justify-content-between align-items-center w-100"
+								type="button" data-target="#collapseFeeExhibit">
+								<span class="reboot font-size-1">RR Summaries</span>
+								<span id="collapseFeeExhibitBadge"
+									class="reboot badge badge-secondary">
+									<i class="reboot fas fa-spinner fa-spin"></i>
+
+								</span>
+							</button>
+						</h5>
+					</div>
+					<div id="ccollapseFeeExhibit" class="reboot collapse"
+						data-parent="#tagged-sections">
+						<!-- Below is populated dynamically VIA JS -->
+						<div class="reboot list-group list-group-flush"></div>
+					</div>
+				</div>
 			</div>
 		</div>
 		

--- a/ixviewer-src/ix.html
+++ b/ixviewer-src/ix.html
@@ -719,6 +719,52 @@
 						<div class="reboot list-group list-group-flush"></div>
 					</div>
 				</div>
+
+				<div class="reboot card" id="tagged-sections-4"
+					data-test="tagged-sections-4">
+					<div class="reboot card-header px-0 py-0">
+						<h5 class="reboot mb-0">
+							<button
+								class="reboot btn btn-link d-flex justify-content-between align-items-center w-100"
+								type="button" data-target="#collapseProspectus">
+								<span class="reboot font-size-1">Prospectus</span>
+								<span id="collapseProspectusBadge"
+									class="reboot badge badge-secondary">
+									<i class="reboot fas fa-spinner fa-spin"></i>
+
+								</span>
+							</button>
+						</h5>
+					</div>
+					<div id="collapseProspectus" class="reboot collapse"
+						data-parent="#tagged-sections">
+						<!-- Below is populated dynamically VIA JS -->
+						<div class="reboot list-group list-group-flush"></div>
+					</div>
+				</div>
+
+				<div class="reboot card" id="tagged-sections-5"
+					data-test="tagged-sections-5">
+					<div class="reboot card-header px-0 py-0">
+						<h5 class="reboot mb-0">
+							<button
+								class="reboot btn btn-link d-flex justify-content-between align-items-center w-100"
+								type="button" data-target="#collapseFeeExhibit">
+								<span class="reboot font-size-1">RR Summaries</span>
+								<span id="collapseFeeExhibitBadge"
+									class="reboot badge badge-secondary">
+									<i class="reboot fas fa-spinner fa-spin"></i>
+
+								</span>
+							</button>
+						</h5>
+					</div>
+					<div id="ccollapseFeeExhibit" class="reboot collapse"
+						data-parent="#tagged-sections">
+						<!-- Below is populated dynamically VIA JS -->
+						<div class="reboot list-group list-group-flush"></div>
+					</div>
+				</div>
 			</div>
 		</div>
 

--- a/ixviewer-src/ix.html
+++ b/ixviewer-src/ix.html
@@ -759,7 +759,7 @@
 							</button>
 						</h5>
 					</div>
-					<div id="ccollapseFeeExhibit" class="reboot collapse"
+					<div id="collapseFeeExhibit" class="reboot collapse"
 						data-parent="#tagged-sections">
 						<!-- Below is populated dynamically VIA JS -->
 						<div class="reboot list-group list-group-flush"></div>

--- a/ixviewer-src/js/app/sections/index.js
+++ b/ixviewer-src/js/app/sections/index.js
@@ -98,6 +98,12 @@ var Sections = {
     Sections.populateParentCollapse('tagged-sections-3', 'collapseRRSummariesBadge', 'RR_Summaries',
       'collapseRRSummaries');
 
+    Sections.populateParentCollapse('tagged-sections-4', 'collapseProspectusBadge', 'Prospectus',
+      'collapseProspectus');
+
+    Sections.populateParentCollapse('tagged-sections-5', 'collapseFeeExhibitBadge', 'Fee_Exhibit',
+      'collapseFeeExhibit');
+
     Sections.formChange();
   },
 

--- a/ixviewer/ix-dev.html
+++ b/ixviewer/ix-dev.html
@@ -735,7 +735,7 @@
 							</button>
 						</h5>
 					</div>
-					<div id="ccollapseFeeExhibit" class="reboot collapse"
+					<div id="collapseFeeExhibit" class="reboot collapse"
 						data-parent="#tagged-sections">
 						<!-- Below is populated dynamically VIA JS -->
 						<div class="reboot list-group list-group-flush"></div>

--- a/ixviewer/ix-dev.html
+++ b/ixviewer/ix-dev.html
@@ -695,6 +695,52 @@
 						<div class="reboot list-group list-group-flush"></div>
 					</div>
 				</div>
+
+				<div class="reboot card" id="tagged-sections-4"
+					data-test="tagged-sections-4">
+					<div class="reboot card-header px-0 py-0">
+						<h5 class="reboot mb-0">
+							<button
+								class="reboot btn btn-link d-flex justify-content-between align-items-center w-100"
+								type="button" data-target="#collapseProspectus">
+								<span class="reboot font-size-1">Prospectus</span>
+								<span id="collapseProspectusBadge"
+									class="reboot badge badge-secondary">
+									<i class="reboot fas fa-spinner fa-spin"></i>
+
+								</span>
+							</button>
+						</h5>
+					</div>
+					<div id="collapseProspectus" class="reboot collapse"
+						data-parent="#tagged-sections">
+						<!-- Below is populated dynamically VIA JS -->
+						<div class="reboot list-group list-group-flush"></div>
+					</div>
+				</div>
+
+				<div class="reboot card" id="tagged-sections-5"
+					data-test="tagged-sections-5">
+					<div class="reboot card-header px-0 py-0">
+						<h5 class="reboot mb-0">
+							<button
+								class="reboot btn btn-link d-flex justify-content-between align-items-center w-100"
+								type="button" data-target="#collapseFeeExhibit">
+								<span class="reboot font-size-1">RR Summaries</span>
+								<span id="collapseFeeExhibitBadge"
+									class="reboot badge badge-secondary">
+									<i class="reboot fas fa-spinner fa-spin"></i>
+
+								</span>
+							</button>
+						</h5>
+					</div>
+					<div id="ccollapseFeeExhibit" class="reboot collapse"
+						data-parent="#tagged-sections">
+						<!-- Below is populated dynamically VIA JS -->
+						<div class="reboot list-group list-group-flush"></div>
+					</div>
+				</div>
 			</div>
 		</div>
 		

--- a/ixviewer/ix.html
+++ b/ixviewer/ix.html
@@ -719,6 +719,52 @@
 						<div class="reboot list-group list-group-flush"></div>
 					</div>
 				</div>
+
+				<div class="reboot card" id="tagged-sections-4"
+					data-test="tagged-sections-4">
+					<div class="reboot card-header px-0 py-0">
+						<h5 class="reboot mb-0">
+							<button
+								class="reboot btn btn-link d-flex justify-content-between align-items-center w-100"
+								type="button" data-target="#collapseProspectus">
+								<span class="reboot font-size-1">Prospectus</span>
+								<span id="collapseProspectusBadge"
+									class="reboot badge badge-secondary">
+									<i class="reboot fas fa-spinner fa-spin"></i>
+
+								</span>
+							</button>
+						</h5>
+					</div>
+					<div id="collapseProspectus" class="reboot collapse"
+						data-parent="#tagged-sections">
+						<!-- Below is populated dynamically VIA JS -->
+						<div class="reboot list-group list-group-flush"></div>
+					</div>
+				</div>
+
+				<div class="reboot card" id="tagged-sections-5"
+					data-test="tagged-sections-5">
+					<div class="reboot card-header px-0 py-0">
+						<h5 class="reboot mb-0">
+							<button
+								class="reboot btn btn-link d-flex justify-content-between align-items-center w-100"
+								type="button" data-target="#collapseFeeExhibit">
+								<span class="reboot font-size-1">RR Summaries</span>
+								<span id="collapseFeeExhibitBadge"
+									class="reboot badge badge-secondary">
+									<i class="reboot fas fa-spinner fa-spin"></i>
+
+								</span>
+							</button>
+						</h5>
+					</div>
+					<div id="ccollapseFeeExhibit" class="reboot collapse"
+						data-parent="#tagged-sections">
+						<!-- Below is populated dynamically VIA JS -->
+						<div class="reboot list-group list-group-flush"></div>
+					</div>
+				</div>
 			</div>
 		</div>
 

--- a/ixviewer/ix.html
+++ b/ixviewer/ix.html
@@ -759,7 +759,7 @@
 							</button>
 						</h5>
 					</div>
-					<div id="ccollapseFeeExhibit" class="reboot collapse"
+					<div id="collapseFeeExhibit" class="reboot collapse"
 						data-parent="#tagged-sections">
 						<!-- Below is populated dynamically VIA JS -->
 						<div class="reboot list-group list-group-flush"></div>

--- a/resources/InstanceReport_Common.xslt
+++ b/resources/InstanceReport_Common.xslt
@@ -419,7 +419,7 @@
     <xsl:variable name="showElementNames" select="ShowElementNames = 'true'"/>
     <xsl:variable name="displayLabelColumn" select="string-length(DisplayLabelColumn) = 0 or DisplayLabelColumn = 'true'"/>
     <xsl:variable name="hasLabelFootnotes" select="Rows/Row/FootnoteIndexer/node()"/>
-    <xsl:variable name="standardPrefixesRegex" select="concat('^(',$standardPrefixes,')_$')"/>
+    <xsl:variable name="standardPrefixesPattern" select="concat('|',$standardPrefixes,'|')"/>
     <xsl:for-each select="Rows/Row">
       <xsl:choose>
         <xsl:when test="IsReportTitle = 'true'"/>
@@ -431,12 +431,12 @@
               <xsl:choose>
                 <xsl:when test="IsSegmentTitle = 'true'"/>
                 <xsl:when test="IsAbstractGroupTitle = 'true'"/>
-                <xsl:when test="contains($standardPrefixesRegex,concat('|',ElementPrefix,'|'))"/>
-                <xsl:otherwise>custom</xsl:otherwise>
+                <xsl:when test="contains($standardPrefixesPattern, substring-before(ElementPrefix, '_'))"/>
+                <xsl:otherwise> custom</xsl:otherwise>
               </xsl:choose>
             </xsl:variable>
             <xsl:if test="$displayLabelColumn">
-              <td class="pl {$custom}" style="border-bottom: 0px;" valign="top">
+              <td class="pl{$custom}" style="border-bottom: 0px;" valign="top">
                 <xsl:call-template name="authRefLink"/>
               </td>
               <xsl:if test="$hasLabelFootnotes">


### PR DESCRIPTION
### Reason for change

(EDGAR 22.2.2 release adds FASB 2022Q3 supplemental taxonomies and fixes a redline removal production error for some previously deployed iXBRL filings.)  This change is to correct regression in 22.2 builds which didn't have needed changes merged.

### Description of change

Syncs to 22.2 EdgarRenderer changes which weren't previously merged to Master in this project.  (Regressed 22.2 update for "Prospectus" groups in ix viewer for N-2 etc)

No changes regarding Q3 FASB or redline in this project branch.

*Codependent with [Arelle project same branch](https://github.com/Arelle/Arelle/pull/237).*

Steps to Test

Local previewing of N-2 and other ix-viewable instances should show up with Prospectus viewing as on sec.gov under 22.2 deployment.

review:
@Arelle/arelle