### PR TITLE
EdgarRenderer Archive Filesource

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -785,6 +785,8 @@ class EdgarRenderer(Cntlr.Cntlr):
         self.renderedFiles = filing.renderedFiles # filing-level rendered files
         if not success:
             self.success = False
+        # block closing filesource when modelXbrl closes because it's used by filingEnd (and may be an archive)
+        modelXbrl.closeFileSource = False
         modelXbrl.profileStat(_("EdgarRenderer process instance {}").format(report.basenames[0]))
 
     def loadLogMessageText(self):
@@ -1016,7 +1018,6 @@ class EdgarRenderer(Cntlr.Cntlr):
                                                 file = filesource.file(_filepath, binary=True)[0]  # returned in a tuple
                                             xbrlZip.writestr(reportedFile, file.read())
                                             file.close()
-                            filesource.close()
                         xbrlZip.close()
                         zipStream.seek(0)
                         if self.reportZip:
@@ -1060,6 +1061,9 @@ class EdgarRenderer(Cntlr.Cntlr):
                 self.success = False # force postprocessingFailure
 
             cntlr.edgarRedlineDocs.clear()
+            
+        # close filesource (which may have been an archive), regardless of success above
+        filesource.close()
             
         if not self.success and self.isDaemon: # not successful
             self.postprocessFailure(filing.options)


### PR DESCRIPTION
#### Reason for change
When running EdgarRenderer from an archive filesource (here, an SEC EIS submission archive), with a referenced jpg file included, filesource was prematurely closed resulting in an exception. 

#### Description of change
In Filesource.py close(), set isOpen=false for isEis filesource
In EdgarRenderer __init__.py, notify modelXbrl to leave filesource open (for EdgarRenderer plugin finalization), and move file source.close out of loop to end of method. 

NOTE: requires EdgarRenderer PR# to also be merged.

#### Steps to Test
Try with an EIS submission archive filesource on a submission with a jpg referenced.

**review**:
@Arelle/arelle
