### PR TITLE
Remove legacy PythonUtil builtin imports

### DIFF
--- a/RefManager.py
+++ b/RefManager.py
@@ -10,8 +10,6 @@ are not subject to domestic copyright protection. 17 U.S.C. 105.
 import os.path, re, lxml, time
 import arelle.ModelDocument
 from arelle.FileSource import openFileSource
-from arelle import PythonUtil # define 2.x or 3.x string types
-PythonUtil.noop(0) # Get rid of warning on PythonUtil import
 
 taxonomyManagerFile = 'TaxonomyAddonManager.xml'
 

--- a/__init__.py
+++ b/__init__.py
@@ -146,8 +146,7 @@ Language of labels:
 VERSION = '3.22.2.2'
 
 from collections import defaultdict
-from arelle import PythonUtil  # define 2.x or 3.x string types
-PythonUtil.noop(0)  # Get rid of warning on PythonUtil import
+from arelle import PythonUtil
 from arelle import (Cntlr, FileSource, ModelDocument, XmlUtil, Version, ModelValue, Locale, PluginManager, WebCache, ModelFormulaObject,
                     ViewFileFactList, ViewFileFactTable, ViewFileConcepts, ViewFileFormulae,
                     ViewFileRelationshipSet, ViewFileTests, ViewFileRssFeed, ViewFileRoleTypes)


### PR DESCRIPTION
Removes a legacy import and reference to a noop function that no longer exists in Arelle