### PR TITLE
EDGAR release 23.1.1 updates

### DIFF
--- a/Inline.py
+++ b/Inline.py
@@ -111,10 +111,10 @@ def saveTargetDocument(filing, modelXbrl, targetDocumentFilename, targetDocument
                                           # no lang on xbrl:xbrl, specific xml:lang on elements which aren't en-US
                                           baseXmlLang=None, defaultXmlLang="en-US")
         if outputZip:
-            targetInstance.saveInstance(overrideFilepath=targetUrl, outputZip=outputZip, updateFileHistory=False, xmlcharrefreplace=True)
+            targetInstance.saveInstance(overrideFilepath=targetUrl, outputZip=outputZip, updateFileHistory=False, xmlcharrefreplace=True, edgarcharrefreplace=True)
         else:
             fh = io.StringIO();
-            targetInstance.saveInstance(overrideFilepath=targetUrl, outputFile=fh, updateFileHistory=False, xmlcharrefreplace=True)
+            targetInstance.saveInstance(overrideFilepath=targetUrl, outputFile=fh, updateFileHistory=False, xmlcharrefreplace=True, edgarcharrefreplace=True)
             fh.seek(0)
             filing.writeFile(targetUrl, fh.read())
             fh.close()


### PR DESCRIPTION
#### Reason for change
EDGAR added circumflex escaping when saving extracted xml instance documents 

#### Description of change
See above

#### Steps to Test
1 - an inline filing with escaped ^'s in a string should result in escaped ^'s in _htm.xml's string.

**review**:
@Arelle/arelle
