### PR TITLE
Excel download XSLT fix

### DIFF
--- a/resources/Summarize_Common.xslt
+++ b/resources/Summarize_Common.xslt
@@ -26,10 +26,8 @@
   <xsl:variable name="isRxp" select="0 &lt; (count(/FilingSummary/BaseTaxonomies/BaseTaxonomy[contains(.,'sec.gov/rxp/20')]))"/>
   <xsl:variable name="isUsgaapOrIfrs" select="0 &lt; (count(/FilingSummary/BaseTaxonomies/BaseTaxonomy[contains(.,'fasb.org/us-gaap/20')]) + count(/FilingSummary/BaseTaxonomies/BaseTaxonomy[contains(.,'fasb.org/srt/20')]) + count(/FilingSummary/BaseTaxonomies/BaseTaxonomy[contains(.,'ifrs.org/taxonomy/20') and contains(.,'/ifrs-full')]))"/>
   <xsl:variable name="isOnlyDei" select="(0 &lt; count(/FilingSummary/BaseTaxonomies/BaseTaxonomy[contains(.,'sec.gov/dei/20')])) and (0 = count(/FilingSummary/BaseTaxonomies/BaseTaxonomy[not(contains(.,'sec.gov/dei/20'))]))"/>
-  <xsl:variable name="isNotFinancialStatement">
-    <!-- only real financial statements get multipart menus with levels I, II, III, IV -->
-    <xsl:value-of select="$isRxp or $isN1a or $isn3n4n6  or $isn2prospectus  or $isfeeexhibit  or $isNcsr or $isProxy or $isSdr or $isOnlyDei "/>
-  </xsl:variable>
+  <!-- only real financial statements get multipart menus with levels I, II, III, IV -->
+  <xsl:variable name="isNotFinancialStatement" select="$isRxp or $isN1a or $isn3n4n6 or $isn2prospectus or $isfeeexhibit or $isNcsr or $isProxy or $isSdr or $isOnlyDei"/>
   <!-- only real financial statements and dei-only 8-k's get useless excel output -->
   <xsl:variable name="mayHaveExcel" select="$isOnlyDei or not($isNotFinancialStatement)"/>
 <!-- uncomment these while you look for syntax errors


### PR DESCRIPTION
The current XLST in the plugin doesn't match renderings on the SEC website. The SEC employs Perl code to produce this menu for renderings on their website while Arelle uses the XSLT. This resolves a bug in the XSLT that prevents the Excel download link from ever showing up.

Easiest way to test is through the Arelle GUI.
[workiva.zip](https://github.com/Arelle/EdgarRenderer/files/12008830/workiva.zip)

master:
<img width="459" alt="Screenshot 2023-07-10 at 6 00 44 PM" src="https://github.com/Arelle/EdgarRenderer/assets/46454775/d81c3a04-df94-43e9-912f-bcb9e29577f5">

this PR:
<img width="459" alt="Screenshot 2023-07-10 at 5 59 56 PM" src="https://github.com/Arelle/EdgarRenderer/assets/46454775/3d669d77-79aa-40bd-b21d-918168ceee79">
