### PR TITLE
GUI launch of ixviewer when no disclosure system selected

### DIFF
--- a/LocalViewer.py
+++ b/LocalViewer.py
@@ -64,6 +64,8 @@ class _LocalViewer(LocalViewer):
                     self.cntlr.addToLog("  ?filename={}".format(_file), messageCode="localViewer:get",level=logging.DEBUG)
                 else:
                     self.cntlr.addToLog("  ?" + ", ".join([f"{k}={v}" for k,v in request.query.items()]),level=logging.DEBUG)
+            elif _file == "ix":
+                return static_file(_file, root=self.reportsFolders[0])
             # check if file is in the current or parent directory (may bve
             _fileDir = self.reportsFolders[int(_report)]
             _fileExists = False

--- a/__init__.py
+++ b/__init__.py
@@ -1190,8 +1190,9 @@ class EdgarRenderer(Cntlr.Cntlr):
                 self.logDebug(_("Exception in filing end processing, traceback: {}").format(traceback.format_exception(*sys.exc_info())))
                 self.success = False # force postprocessingFailure
 
-            cntlr.editedIxDocs.clear()
-            cntlr.redlineIxDocs.clear()
+        cntlr.editedIxDocs.clear() # deref modelXbrls even if unsuccessful
+        cntlr.redlineIxDocs.clear()
+        cntlr.editedModelXbrls.clear()
 
         # close filesource (which may have been an archive), regardless of success above
         filesource.close()
@@ -1635,7 +1636,7 @@ def edgarRendererGuiRun(cntlr, modelXbrl, *args, **kwargs):
                     filingSummaryTree = etree.parse(os.path.join(edgarRenderer.reportsFolder, "FilingSummary.xml"))
                     for reportElt in filingSummaryTree.iter(tag="Report"):
                         if reportElt.get("instance"):
-                            openingUrl = "ix.xhtml?doc={}&xbrl=true".format(reportElt.get("instance"))
+                            openingUrl = f"ix?doc=/{_localhost.rpartition('/')[2]}/{reportElt.get('instance')}&xbrl=true"
                             break
                 if not openingUrl: # open SEC Mustard Menu
                     openingUrl = ("FilingSummary.htm", "Rall.htm")[_combinedReports]

--- a/__init__.py
+++ b/__init__.py
@@ -771,7 +771,7 @@ class EdgarRenderer(Cntlr.Cntlr):
         modelXbrl.profileActivity()
         self.setProcessingFolder(modelXbrl.fileSource, report.filepaths[0]) # use first of possibly multi-doc IXDS files
         # if not reportZip and reportsFolder is relative, make it relative to source file location (on first report)
-        if success and not filing.reportZip and self.initialReportsFolder and len(filing.reports) == 1:
+        if (success or not self.noRenderingWithError) and not filing.reportZip and self.initialReportsFolder and len(filing.reports) == 1:
             if not os.path.isabs(self.initialReportsFolder):
                 # try input file's directory
                 if os.path.exists(self.processingFolder) and os.access(self.processingFolder, os.W_OK | os.X_OK):


### PR DESCRIPTION
## Issue

GUI operation with no disclosure system selected (or non-EFM selected) failed to launch ixviewer or ixviewer-plus as usual.

GUI operation without noRenderingWithError but errors detected failed to place reportsDirectory (usually "out") in proper location, resulting in "out" having been child of last-selected/opened directory instead as sibling to actually-opened instance.