### PR TITLE
EdgarRenderer updates for python 3.12 compatibility

### DIFF
--- a/Cube.py
+++ b/Cube.py
@@ -123,7 +123,7 @@ class Cube(object):
 
         # gets rid of the curly brackets if it has transposed, unlabeled or elements inside.
         # there are examples (nils) that have other stuff inside of curly brackets, so we keep those.
-        cubeName = re.sub('\s*\{\s*((?P<t>transposed)|(?P<u>unlabeled)|(?P<e>elements))\s*\}\s*', handleIndex, cubeName, flags=re.IGNORECASE)
+        cubeName = re.sub(r'\s*\{\s*((?P<t>transposed)|(?P<u>unlabeled)|(?P<e>elements))\s*\}\s*', handleIndex, cubeName, flags=re.IGNORECASE)
 
         isTransposed = isUnlabeled = isElements = False
         if indexList[0] < 99999: # if transposed is present, the first one of the three mentioned wins

--- a/Filing.py
+++ b/Filing.py
@@ -183,7 +183,7 @@ class Filing(object):
         # SEC and FASB namespaces have the same structure, IFRS namespaces not so much.
         self.stdNsTokens = set()
         self.ifrsNamespace = self.usgaapNamespace = self.deiNamespace = None
-        nspattern = re.compile('.*((xbrl\.sec\.gov|fasb\.org)/(?P<prefix>[^/]+)/20.*|ifrs\.org/taxonomy/20[^/]*/(?P<other>ifrs)).*')
+        nspattern = re.compile(r'.*((xbrl\.sec\.gov|fasb\.org)/(?P<prefix>[^/]+)/20.*|ifrs\.org/taxonomy/20[^/]*/(?P<other>ifrs)).*')
         for n in self.modelXbrl.namespaceDocs.keys():
             if n is None: continue
             m = nspattern.match(n)

--- a/RefManager.py
+++ b/RefManager.py
@@ -39,7 +39,7 @@ class RefManager(object):
             if doc.targetNamespace in namespacesInFacts:
                 parsedUri = urlparse(fileUri)
                 fileBasename = os.path.basename(parsedUri.path)
-                if re.compile('.*\.xsd$').match(fileBasename): # Assume we only care about urls ending in .xsd
+                if re.compile(r'.*\.xsd$').match(fileBasename): # Assume we only care about urls ending in .xsd
                     xp = "/TaxonomyAddonManager/TaxonomyList/TaxonomyAddon[Taxonomy[.='" + fileBasename + "']]/*/string"
                     moreUrls = self.tree.xpath(xp)
                     for u in moreUrls:

--- a/Report.py
+++ b/Report.py
@@ -1195,7 +1195,7 @@ class Report(object):
         factList = []
         yMax = 0.0
         yMin = 0.0
-        isOefBarChartFact = re.compile('^\{http://xbrl.sec.gov/oef/.*\}AnnlRtrPct$') # WcH in a hurry 4/6/2023
+        isOefBarChartFact = re.compile(r'^\{http://xbrl.sec.gov/oef/.*\}AnnlRtrPct$') # WcH in a hurry 4/6/2023
         for row in self.rowList:
             for fact in row.factList:
                 m = Utils.isBarChartFactRegex.match(fact.qname.clarkNotation)

--- a/Summary.py
+++ b/Summary.py
@@ -940,14 +940,14 @@ class InstanceSummary(object):
         else:
             return Uncategorized
 
-matchStatement = re.compile('.* +\- +Statement +\- .*')
-matchDisclosure = re.compile('.* +\- +Disclosure +\- +.*')
-matchDocument = re.compile('.* +\- +Document +\- +.*')
-matchParenthetical = re.compile('.*\-.+-.*Paren.+')
-matchPolicy = re.compile('.*\(.*Polic.*\).*')
-matchTable = re.compile('.*\(Table.*\).*')
-matchDetail = re.compile('.*\(Detail.*\).*')
-matchHttp = re.compile('^http://')
+matchStatement = re.compile(r'.* +\- +Statement +\- .*')
+matchDisclosure = re.compile(r'.* +\- +Disclosure +\- +.*')
+matchDocument = re.compile(r'.* +\- +Document +\- +.*')
+matchParenthetical = re.compile(r'.*\-.+-.*Paren.+')
+matchPolicy = re.compile(r'.*\(.*Polic.*\).*')
+matchTable = re.compile(r'.*\(Table.*\).*')
+matchDetail = re.compile(r'.*\(Detail.*\).*')
+matchHttp = re.compile(r'^http://')
 
 def isStatement(longName):
     return matchStatement.match(longName) is not None

--- a/Utils.py
+++ b/Utils.py
@@ -74,16 +74,16 @@ def booleanFromString(x):
     else:
         return (x.casefold() == "true")
 
-isImageRegex = re.compile('.*\.(jpg|gif|png)$')
-isXmlRegex = re.compile('.*\.x(ml|sd)')
-isEfmRegex = re.compile('.*[0-9]{8}((_(cal|def|lab|pre))?\.xml|\.xsd)$')
-isInlineRegex = re.compile('.*\.htm$')
-isZipRegex = re.compile('.*\.zip$')
-isHttpRegex = re.compile('^http(s)?://.*')
-isSecNamespaceRegex = re.compile('^http(s)?://xbrl.sec.gov/.*')
+isImageRegex = re.compile(r'.*\.(jpg|gif|png)$')
+isXmlRegex = re.compile(r'.*\.x(ml|sd)')
+isEfmRegex = re.compile(r'.*[0-9]{8}((_(cal|def|lab|pre))?\.xml|\.xsd)$')
+isInlineRegex = re.compile(r'.*\.htm$')
+isZipRegex = re.compile(r'.*\.zip$')
+isHttpRegex = re.compile(r'^http(s)?://.*')
+isSecNamespaceRegex = re.compile(r'^http(s)?://xbrl.sec.gov/.*')
 isEfmStandardNamespaceRegex = re.compile('^http(s)?://.*(' + "|".join(efmStandardAuthorities) + ")/.*")
 isEfmInvestNamespaceRegex = re.compile('^http(s)?://.*(' + "|".join(efmStandardAuthorities) + ")/invest.*")
-isBarChartFactRegex = re.compile('^\{http://xbrl.sec.gov/(?P<family>rr|oef)/.*\}AnnualReturn(?P<year>[0-9]{4})')
+isBarChartFactRegex = re.compile(r'^\{http://xbrl.sec.gov/(?P<family>rr|oef)/.*\}AnnualReturn(?P<year>[0-9]{4})')
 
 def isImageFilename(path):
     return isImageRegex.match(path) and True
@@ -127,8 +127,8 @@ def hasCustomNamespace(thing):
                 return hasCustomNamespace(getattr(thing, a))
     return False
 
-isRoleNotRenderedRegex = re.compile('^https?://xbrl.sec.gov/.*/notRendered$')
-isElementNotRenderedRegex = re.compile('^\{http://xbrl.sec.gov/ffd/.*\}OffsetClmdInd$')
+isRoleNotRenderedRegex = re.compile(r'^https?://xbrl.sec.gov/.*/notRendered$')
+isElementNotRenderedRegex = re.compile(r'^\{http://xbrl.sec.gov/ffd/.*\}OffsetClmdInd$')
 
 def isNotRendered(factOrRole):
     if type(factOrRole) == str:
@@ -231,10 +231,10 @@ def handleDuration(valueStr):
 
     # so lookahead 1 and 2 are basically conditions, and the rest of the regex actually consumes the xs:duration pattern.
 
-    lookAhead1 = '(?=(\d+Y|\d+M|\d+D|T\d+H|T\d+M|T(\d+|\d+\.\d+)S))'
-    lookAhead2 = '(?=(\d+H|\d+M|(\d+|\d+\.\d+)S))'
-    beforeT = '(?P<minus>-?)P' + lookAhead1 + '((?P<y>\d+)Y)?((?P<mon>\d+)M)?((?P<d>\d+)D)?'
-    TAndAfter = '(T' + lookAhead2 + '((?P<h>\d+)H)?((?P<min>\d+)M)?((?P<s>\d+|\d+\.\d+)S)?)?'
+    lookAhead1 = r'(?=(\d+Y|\d+M|\d+D|T\d+H|T\d+M|T(\d+|\d+\.\d+)S))'
+    lookAhead2 = r'(?=(\d+H|\d+M|(\d+|\d+\.\d+)S))'
+    beforeT = r'(?P<minus>-?)P' + lookAhead1 + r'((?P<y>\d+)Y)?((?P<mon>\d+)M)?((?P<d>\d+)D)?'
+    TAndAfter = r'(T' + lookAhead2 + r'((?P<h>\d+)H)?((?P<min>\d+)M)?((?P<s>\d+|\d+\.\d+)S)?)?'
 
     # probably don't need to strip with fact.xValue?
     return re.sub(re.compile(beforeT + TAndAfter), durationPrettyPrint, valueStr.strip())
@@ -286,7 +286,7 @@ def strFactValue(fact, preferredLabel=None, filing=None, report=None):
 
 def prettyPrintQname(localName):
     # \g<1> will match to the char that matched ([a-z]) and similarly for \g<2>.
-    return re.sub('([a-z])([A-Z0-9])', '\g<1> \g<2>', localName)
+    return re.sub(r'([a-z])([A-Z0-9])', r'\g<1> \g<2>', localName)
 
 
 def isTypeQnameDerivedFrom(modelXbrl, typeQname, predicate):

--- a/Xlout.py
+++ b/Xlout.py
@@ -27,7 +27,7 @@ wordInNumPattern = re.compile(r"\s*([_A-Za-z\xC0-\xD6\xD8-\xF6\xF8-\xFF\u0100-\u
                               r"\s*([$€¥£]\s*)?[(]?\s*[+-]?[0-9,]+([.][0-9]*)?[)-]?\s*$")
 dateTimePattern = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-2][0-9]:[0-6][0-9]:[0-6][0-9]$")
 datePattern = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$")
-forbiddenChars = re.compile('[\\*?:/\[\]]')
+forbiddenChars = re.compile(r'[\\*?:/\[\]]')
 
 OUTPUT_FILE_NAME = "Financial_Report.xlsx"
 


### PR DESCRIPTION
Python 3.12 requires strict observance of regex patterns, many in EdgarRenderer were missing the "r" prefix for raw strings containing backslash escaping characters.

Run conformance test and GUI operations to confirm changes (under python 3.12, of course!)