### PR TITLE
Edgar 24.1 Update2

### DIFF
--- a/Filing.py
+++ b/Filing.py
@@ -1232,7 +1232,7 @@ class Member(object):
             typedValue = getattr(typedElt, "xValue", None)
             try:
                 self.typedKey.append(typedElt.modelXbrl.qnameConcepts[typedElt.qname].type.facets["enumeration"][typedElt.xValue].objectIndex)
-            except (AttributeError, IndexError, TypeError):
+            except (AttributeError, IndexError, KeyError, TypeError):
                 self.typedKey.append(typedValue)
             if isinstance(typedValue, arelle.ModelValue.IsoDuration):
                 self.typedValue.append(typedValue.viewText()) # duration in words instead of lexical notation


### PR DESCRIPTION
#### Reason for change
 * multi-IXDS typed dimensions set correct target modelXbrl reference

#### Description of change
 * multi-IXDS loaded from GUI use target instance's typed dimension objects


#### Steps to Test
 * multi-IXDS: submit primary doc using dei-2022 and fee exhibit using dei-2024, raised exception in EdgarRenderer before fix

**review**:
@Arelle/arelle
