### PR TITLE
Edgar 24.1 Update 4

### DIFF
--- a/Filing.py
+++ b/Filing.py
@@ -23,11 +23,11 @@ from . import Cube, Embedding, Report, PresentationGroup, Summary, Utils, Xlout
 usGaapOrIfrsPattern = re.compile(".*/fasb[.]org/(us-gaap|srt)/20|.*/xbrl[.]ifrs[.]org/taxonomy/[0-9-]{10}/ifrs-full", re.I)
 deiPattern = re.compile(".*/xbrl[.]sec[.]gov/dei/20", re.I)
 
-def mainFun(controller, modelXbrl, outputFolderName, transform=None, suplSuffix=None, rFilePrefix=None, altFolder=None, altTransform=None, altSuffix=None):
+def mainFun(controller, modelXbrl, outputFolderName, transform=None, suplSuffix=None, rFilePrefix=None, altFolder=None, altTransform=None, altSuffix=None, zipDir=None):
     if "EdgarRenderer/Filing.py#mainFun" in modelXbrl.arelleUnitTests:
         raise arelle.PythonUtil.pyNamedObject(modelXbrl.arelleUnitTests["EdgarRenderer/Filing.py#mainFun"], "EdgarRenderer/Filing.py#mainFun")
     _funStartedAt = time.time()
-    filing = Filing(controller, modelXbrl, outputFolderName, transform, suplSuffix, rFilePrefix, altFolder, altTransform, altSuffix)
+    filing = Filing(controller, modelXbrl, outputFolderName, transform, suplSuffix, rFilePrefix, altFolder, altTransform, altSuffix, zipDir)
     controller.logDebug("Filing initialized {:.3f} secs.".format(time.time() - _funStartedAt)); _funStartedAt = time.time()
     filing.populateAndLinkClasses()
     controller.logDebug("Filing populateAndLinkClasses {:.3f} secs.".format(time.time() - _funStartedAt)); _funStartedAt = time.time()
@@ -160,7 +160,7 @@ def mainFun(controller, modelXbrl, outputFolderName, transform=None, suplSuffix=
 
 
 class Filing(object):
-    def __init__(self, controller, modelXbrl, outputFolderName, transform, suplSuffix, rFilePrefix, altFolder, altTransform, altSuffix):
+    def __init__(self, controller, modelXbrl, outputFolderName, transform, suplSuffix, rFilePrefix, altFolder, altTransform, altSuffix, zipDir):
         self.modelXbrl = modelXbrl
         self.transform = transform
         self.suplSuffix = suplSuffix
@@ -290,6 +290,7 @@ class Filing(object):
         if controller.reportZip:
             self.fileNameBase = None
             self.reportZip = controller.reportZip
+            self.zipDir = zipDir or ""
         elif outputFolderName is not None:
             # self.fileNameBase = os.path.normpath(os.path.join(os.path.dirname(controller.webCache.normalizeUrl(modelXbrl.fileSource.basefile)) ,outputFolderName))
             self.fileNameBase = outputFolderName

--- a/Inline.py
+++ b/Inline.py
@@ -29,7 +29,7 @@ DEFAULT_INSTANCE_EXT = ".xml"  # the extension on the instance to be saved
 DEFAULT_DISTINGUISHING_SUFFIX = "_htm."  # suffix tacked onto the base name of the source inline document
 USUAL_INSTANCE_EXTS = {"xml", "xbrl"}
 
-def saveTargetDocumentIfNeeded(cntlr, options, modelXbrl, filing, suffix="_htm.", iext=".xml", altFolder=None, suplSuffix=None):
+def saveTargetDocumentIfNeeded(cntlr, options, modelXbrl, filing, suffix="_htm.", iext=".xml", altFolder=None, suplSuffix=None, zipDir=None):
     if (modelXbrl is None): return
     if modelXbrl.modelDocument.type not in (Type.INLINEXBRL, Type.INLINEXBRLDOCUMENTSET):
         cntlr.logTrace(_("No Inline XBRL document."))
@@ -60,6 +60,7 @@ def saveTargetDocumentIfNeeded(cntlr, options, modelXbrl, filing, suffix="_htm."
 
     filingZip = None
     filingFiles = None
+    _zipDir = None
     if options.saveTargetFiling:
         targetFilename = os.path.basename(targetFilename)
         if cntlr.reportZip:
@@ -81,9 +82,10 @@ def saveTargetDocumentIfNeeded(cntlr, options, modelXbrl, filing, suffix="_htm."
     else:
          if cntlr.reportZip:
              filingZip = cntlr.reportZip
+             _zipDir = zipDir # use zipDir for rest API returned redline/redact extracted instance
 
     saveTargetDocument(filing, modelXbrl, targetFilename, targetSchemaRefs,
-                       outputZip=filingZip, filingFiles=filingFiles, suffix=suffix, iext=iext, suplSuffix=suplSuffix)
+                       outputZip=filingZip, filingFiles=filingFiles, suffix=suffix, iext=iext, suplSuffix=suplSuffix, zipDir=_zipDir)
 
     if options.saveTargetFiling:
         instDir = os.path.dirname(modelDocument.uri)  # TODO: will this work if the modelDocument was remote?
@@ -102,7 +104,7 @@ def saveTargetDocumentIfNeeded(cntlr, options, modelXbrl, filing, suffix="_htm."
 
 def saveTargetDocument(filing, modelXbrl, targetDocumentFilename, targetDocumentSchemaRefs,
                        outputZip=None, filingFiles=None,
-                       suffix=DEFAULT_DISTINGUISHING_SUFFIX, iext=DEFAULT_INSTANCE_EXT, suplSuffix=None):
+                       suffix=DEFAULT_DISTINGUISHING_SUFFIX, iext=DEFAULT_INSTANCE_EXT, suplSuffix=None, zipDir=None):
     sourceDir = os.path.dirname(modelXbrl.modelDocument.filepath)
     targetUrlParts = targetDocumentFilename.rpartition(".")
     targetUrl = targetUrlParts[0] + suffix + targetUrlParts[2]
@@ -113,7 +115,7 @@ def saveTargetDocument(filing, modelXbrl, targetDocumentFilename, targetDocument
                                           # no lang on xbrl:xbrl, specific xml:lang on elements which aren't en-US
                                           baseXmlLang=None, defaultXmlLang="en-US", skipInvalid=True)
         if outputZip:
-            targetInstance.saveInstance(overrideFilepath=targetUrl, outputZip=outputZip, updateFileHistory=False, xmlcharrefreplace=True, edgarcharrefreplace=True)
+            targetInstance.saveInstance(overrideFilepath=targetUrl, outputZip=outputZip, updateFileHistory=False, xmlcharrefreplace=True, edgarcharrefreplace=True, zipDir=zipDir)
         else:
             fh = io.StringIO();
             targetInstance.saveInstance(overrideFilepath=targetUrl, outputFile=fh, updateFileHistory=False, xmlcharrefreplace=True, edgarcharrefreplace=True, skipInvalid=True)

--- a/IoManager.py
+++ b/IoManager.py
@@ -47,17 +47,17 @@ def absPathOnPythonPath(controller, filename):  # if filename is relative, find 
     controller.logDebug("No such location {} found in sys path dirs {}.".format(filename, pathdirs))
     return None
 
-def writeXmlDoc(filing, etree, reportZip, reportFolder, filename):
+def writeXmlDoc(filing, etree, reportZip, reportFolder, filename, zipDir=""):
     xmlText = treeToString(etree.getroottree(), method='xml', with_tail=False, pretty_print=True, encoding='utf-8', xml_declaration=True)
     if reportZip:
-        reportZip.writestr(filename, xmlText)
+        reportZip.writestr(zipDir + filename, xmlText)
     elif reportFolder is not None:
         filing.writeFile(os.path.join(reportFolder, filename), xmlText)
 
-def writeHtmlDoc(filing, root, reportZip, reportFolder, filename):
+def writeHtmlDoc(filing, root, reportZip, reportFolder, filename, zipDir=""):
     htmlText =  treeToString(root, method='html', with_tail=False, pretty_print=True, encoding='utf-8')
     if reportZip:
-        reportZip.writestr(filename, htmlText)
+        reportZip.writestr(zipDir + filename, htmlText)
     elif reportFolder is not None:
         filing.writeFile(os.path.join(reportFolder, filename), htmlText)
 

--- a/Report.py
+++ b/Report.py
@@ -1155,7 +1155,7 @@ class Report(object):
         reportSummary.xmlFileName = baseName
         xmlText = treeToString(tree, xml_declaration=True, encoding='utf-8', pretty_print=True)
         if self.filing.reportZip:
-            self.filing.reportZip.writestr(baseName, xmlText)
+            self.filing.reportZip.writestr(self.filing.zipDir + baseName, xmlText)
             self.controller.renderedFiles.add(baseName)
         elif self.filing.fileNameBase is not None:
             self.controller.writeFile(os.path.join(self.filing.fileNameBase, baseName), xmlText)
@@ -1178,7 +1178,7 @@ class Report(object):
             result = self.filing.transform(tree,**keywordArgs)
         htmlText = treeToString(result,method='html',with_tail=False,pretty_print=True,encoding='us-ascii')
         if self.filing.reportZip:
-            self.filing.reportZip.writestr(baseName, htmlText)
+            self.filing.reportZip.writestr(self.filing.zipDir + baseName, htmlText)
             self.controller.renderedFiles.add(baseName)
         elif self.filing.fileNameBase is not None:
             self.controller.writeFile(os.path.join(self.filing.fileNameBase, baseName), htmlText)
@@ -1886,7 +1886,7 @@ class Cell(object):
                     fig.savefig(file, bbox_inches='tight', dpi=150)
                     file.seek(0)
                     if self.filing.reportZip:
-                        self.filing.reportZip.writestr(pngname, file.read())
+                        self.filing.reportZip.writestr(self.filing.zipDir + pngname, file.read())
                     else:
                         self.filing.controller.writeFile(os.path.join(self.filing.fileNameBase, pngname), file.read())
                     file.close()

--- a/Xlout.py
+++ b/Xlout.py
@@ -58,7 +58,7 @@ class XlWriter(object):
         del self.simplified_transform
 
 
-    def save(self, suffix=""):
+    def save(self, suffix="", zipDir=""):
         if len(self.wb.worksheets)>1:
             self.wb.remove(self.wb.worksheets[0])
         if not (self.controller.reportZip or self.outputFolderName is not None):
@@ -69,7 +69,7 @@ class XlWriter(object):
         file.seek(0)
         outputFileName = OUTPUT_FILE_NAME + suffix
         if self.controller.reportZip:
-            self.controller.reportZip.writestr(outputFileName, file.read())
+            self.controller.reportZip.writestr(zipDir + outputFileName, file.read())
         else:
             self.controller.writeFile(os.path.join(self.outputFolderName, outputFileName), file.read())
         file.close()

--- a/__init__.py
+++ b/__init__.py
@@ -1406,7 +1406,7 @@ class EdgarRenderer(Cntlr.Cntlr):
         # non-GUI (cmd line) options.keepOpen kept modelXbrls open, use keepFilingOpen to block closing here
         if not options.keepFilingOpen and not self.isRunningUnderTestcase():
             for report in filing.reports:
-                report.modelXbrl.close()
+                self.modelManager.close(report.modelXbrl)
 
         # close filesource (which may have been an archive), regardless of success above
         filesource.close()


### PR DESCRIPTION
#### Reason for change
 * Please wait to merge, EDGAR interim update planned for April 6 with any further changes to EdgarRenderer
 
 * Redline and redaction were re-running xbrl and EFM validation even when there were no changes to facts or footnotes, annoying author and users.
 
 * REST API broke with introduction of redaction 

#### Description of change
 * After redline removal and redaction, perform only xhtml schema re-validation unless any fact or footnote is affected by redaction, in which case also perform xbrl and efm revalidation. 

 * Fix API operation for 2nd and subsequent validations

#### Steps to Test
 * EFM suite (latest update available)
 * Redaction to force a schema error, such as the redact style on a single &lt;td> element &lt;tr>, not containing any facts, which when redacted would cause an xhtml schema error, but no xbrl or efm validation should run (info msg indicates xhtml re-validation only)
 * Redaction when removal causes xbrl and efm validation, include a required fact, such as doc period end date, in redacted section. (info msg indicates xbrl and efm are re-validated)
 * Code inspection
 * REST API with multiple validation calls

**review**:
@Arelle/arelle


'