### PR TITLE
Use relative paths with lxml ElementTree find methods

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1148,7 +1148,7 @@ class EdgarRenderer(Cntlr.Cntlr):
                             if redactTgtElts: # if any redacted continued at elements
                                 for ixdsHtmlRootElt in getattr(modelXbrl, "ixdsHtmlElements", ()):
                                     hasEditedCont = False
-                                    for e in ixdsHtmlRootElt.getroottree().iterfind("//{http://www.xbrl.org/2013/inlineXBRL}*[@continuedAt]"):
+                                    for e in ixdsHtmlRootElt.getroottree().iterfind(".//{http://www.xbrl.org/2013/inlineXBRL}*[@continuedAt]"):
                                         contAt = e.get("continuedAt", None)
                                         while contAt in redactTgtElts: # may be multiple continuations in redacted sections
                                             nextContAtElt = redactTgtElts[contAt]
@@ -1864,7 +1864,7 @@ def edgarRendererDetectRedlining(modelDocument, *args, **kwargs):
     cntlr = modelDocument.modelXbrl.modelManager.cntlr
     foundMatchInDoc = False
     if modelDocument.type == ModelDocument.Type.INLINEXBRL and (not cntlr.hasGui or cntlr.redlineMode.get()):
-        for e in modelDocument.xmlRootElement.getroottree().iterfind("//{http://www.w3.org/1999/xhtml}*[@style]"):
+        for e in modelDocument.xmlRootElement.getroottree().iterfind(".//{http://www.w3.org/1999/xhtml}*[@style]"):
             rlMatch = redliningPattern.match(e.get("style",""))
             if rlMatch:
                 if not hasattr(cntlr, "editedIxDocs"):
@@ -1882,7 +1882,7 @@ def edgarRendererDetectRedlining(modelDocument, *args, **kwargs):
 def edgarRendererRemoveRedlining(modelDocument, *args, **kwargs):
     # strip redlining from modelDocument
     matchedElts = []
-    for e in modelDocument.xmlRootElement.getroottree().iterfind("//{http://www.w3.org/1999/xhtml}*[@style]"):
+    for e in modelDocument.xmlRootElement.getroottree().iterfind(".//{http://www.w3.org/1999/xhtml}*[@style]"):
         rlMatch = redliningPattern.match(e.get("style",""))
         if rlMatch:
             matchedElts.append(e) # can't prune tree while iterating through it

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 lxml>=4.6.3
 matplotlib>=3.4.2
-openpyxl>==3.0.7
+openpyxl>=3.0.7


### PR DESCRIPTION
See https://github.com/Arelle/Arelle/pull/1149 for more details. Absolute paths used with `ElementTree.iterfind()` always only ever searched child paths. With the latest versions of lxml an exception is thrown if absolute paths are used.

> This PR addresses an issue identified with the use of absolute paths in lxml versions prior to 5.1.1, which can lead to misleading search paths when using ElementTree.iterfind, ElementTree.find, and ElementTree.findall. For more context, refer to the [lxml bug #2059977](https://bugs.launchpad.net/lxml/+bug/2059977).
> 
> In versions of lxml prior to 5.1.1, using absolute paths with the mentioned methods would only match child elements, not including the root element, which could lead to misleading element matching. Starting with version 5.1.1, an attempt was made to issue a warning for such usage, but due to a bug, a SyntaxError is thrown instead.