### PR TITLE
Rest API tester for EdgarRenderer, rest API with redline/redact

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1082,10 +1082,7 @@ class EdgarRenderer(Cntlr.Cntlr):
                                 _srcfilepath = os.path.join(filesource.baseurl, _filepath)
                             else:
                                 _srcfilepath = os.path.join(_xbrldir, _filepath)
-                            if sourceZipStream is not None:
-                                file = FileSource.openFileSource(_srcfilepath, cntlr, sourceZipStream).file(_srcfilepath, binary=True)[0]
-                            else:
-                                file = filesource.file(_srcfilepath, binary=True)[0]  # returned in a tuple
+                            file = FileSource.openFileSource(_srcfilepath, cntlr, sourceZipStream).file(_srcfilepath, binary=True)[0]
                             with file as fout:  # returned in a tuple
                                 serializedDoc = fout.read()
                         else:


### PR DESCRIPTION
Develop initial version of REST API tester and correct EdgarRenderer behavior with rest-POSTed zip files and zip results

#### Reason for change
 * Rest API did not have a test suite
 
 * EdgarRenderer rest API was not behaving correctly for redline or redact examples which resulted in separate private results and dissem subdirectory for public results.

#### Description of change
 * Implement initial attempt at a REST API tester
     * Utilize EDGAR interactive data test suite examples with GET and POST 
     * Demonstrate operation with reference to server-located files and with POSTed zips of submisssion files

#### Steps to Test
  * Code walk through of tester
  * Identify additional tests (from test suite or from sec.gov prior filings) which would be worth adding to suite
  * Test GET or POST operation in *your* integration of Arelle with EdgarRenderer redline, redact and or vanilla samples

**review**:
@Arelle/arelle
