### PR TITLE
EDGAR 24.1.1.u2 preview

### DIFF
--- a/Cube.py
+++ b/Cube.py
@@ -334,8 +334,8 @@ class Cube(object):
             self.controller.logDebug("Special sort of {} {} needed".format(axisQname,giveMemGetPositionDict))
             prefix = axis.prefix
             nsuri = axis.namespaceURI
-            ordering = [arelle.ModelObject.QName(prefix,nsuri,name) for name in members]
-            overrideordering = [arelle.ModelObject.QName(prefix,nsuri,name) for name in lastmembers]
+            ordering = [arelle.ModelValue.QName(prefix,nsuri,name) for name in members]
+            overrideordering = [arelle.ModelValue.QName(prefix,nsuri,name) for name in lastmembers]
             memberList = Utils.heapsort(memberList,(lambda x,y: Utils.compareInOrdering(x,y,ordering,overrideordering)))
             giveMemGetPositionDict = dict([(x,i) for i,x in enumerate(memberList)])
             self.controller.logDebug("Resulted in {}".format(giveMemGetPositionDict))


### PR DESCRIPTION
### Reason for change
 * Wrong class in validation caused exception.
 * Nested facts with transformation missing on outer (invalid) fact corrupted inner (valid) fact
 * Redaction of initial segment of continuation chain corrected
#### In [Arelle PR](https://github.com/Arelle/Arelle/pull/1198) 
 * Correct DQC 0076 to allow nils

### Description of change
 * See above

### Steps to Test
 * Code inspection
 * Private test filings
 * Test suite, regression tests

review:
@Arelle/arelle