### PR TITLE
Return early if no visible columns RemoveStuntedCashFlowColumns

### DIFF
--- a/Filing.py
+++ b/Filing.py
@@ -1020,6 +1020,8 @@ class Filing(object):
 
     def RemoveStuntedCashFlowColumns(self,report):
         visibleColumns = [col for col in report.colList if (not col.isHidden and col.startEndContext is not None)]
+        if not visibleColumns:
+            return
         didWeHideAnyCols = False
         remainingVisibleColumns = visibleColumns.copy()
         maxMonths = max(col.startEndContext.numMonths for col in visibleColumns)


### PR DESCRIPTION
If there are no "visible columns" as defined [here](https://github.com/Arelle/EdgarRenderer/blob/88d5946ec87261c3f3eaa83747e2c01fa97f340d/Filing.py#L1022), the `max` call [here](https://github.com/Arelle/EdgarRenderer/blob/88d5946ec87261c3f3eaa83747e2c01fa97f340d/Filing.py#L1025) raises an exception: "max() iterable argument is empty".

The rest of the function is effectively a no-op when `visibleColumns` is empty anyway, so simply exiting early is a simple solution.

@hefischer 