### PR TITLE
fix phantom option in webserver mode of EdgarRenderer

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -755,7 +755,7 @@ class EdgarRenderer(Cntlr.Cntlr):
         else: # options previously initialized
             self.copyReAttrOptions(options)
         # Transfer daemonCreatedFilders to this EdgarRenderer to deal with at filingEnd
-        if hasattr(options, "daemonCreatedFolders"):
+        if hasattr(options, "daemonCreatedFolders") and options.daemonCreatedFolders: # not None or empty list
             self.createdFolders.extend(options.daemonCreatedFolders)
             del options.daemonCreatedFolders # don't pass to any subsequent independent filing if any
         mdlMgr = cntlr.modelManager


### PR DESCRIPTION
See googlegroups thread "Web Service Issues with Latest Arelle Version" initially on Tuesday, August 6, 2024

Something changed in command line library or options where a phantom option not intended to exist in webserver options shows up as None instead of non-existant.  This option was used in EdgarRenderer operation long ago, in a daemon mode, and is not relevant to WebServer API operation.  However hitting that code caused an exception in initializing EdgarRenderer and self.loopnum being uninitialized, as reported.

To test, one can make this plugin's one-line change into their plugin/EdgarRenderer/__init__.py and see if the web server works again.